### PR TITLE
remove config flag conflict in datafusion runner

### DIFF
--- a/runners/datafusion-rust/src/main.rs
+++ b/runners/datafusion-rust/src/main.rs
@@ -24,7 +24,7 @@ struct Opt {
     debug: bool,
 
     /// Optional path to config file
-    #[structopt(short, long, parse(from_os_str))]
+    #[structopt(long, parse(from_os_str))]
     config_path: Option<PathBuf>,
 
     /// Path to queries
@@ -157,7 +157,7 @@ pub async fn main() -> Result<()> {
                 opt.iterations,
                 &mut results,
             )
-                .await?;
+            .await?;
         }
         _ => {
             let num_queries = opt.num_queries.unwrap();
@@ -176,7 +176,7 @@ pub async fn main() -> Result<()> {
                     opt.iterations,
                     &mut results,
                 )
-                    .await;
+                .await;
                 match result {
                     Ok(_) => {}
                     Err(e) => println!("Fail: {}", e),


### PR DESCRIPTION
two flags with the same short name (concurrency, config_path) was panicking the datafusion-rust runner. Other changes are rustfmt. I couldn't find any usages of this runner so not sure if anywhere was using the short form of the config_path flag before