### PR TITLE
clear the cached tables before each query execution

### DIFF
--- a/runners/datafusion-comet/tpcbench.py
+++ b/runners/datafusion-comet/tpcbench.py
@@ -61,6 +61,7 @@ def main(benchmark: str, data_path: str, query_path: str, iterations: int, outpu
         print(f"Starting iteration {iteration} of {iterations}")
 
         for query in range(1, num_queries+1):
+            spark.catalog.clearCache()
             spark.sparkContext.setJobDescription(f"{benchmark} q{query}")
 
             # read text file


### PR DESCRIPTION
## Which issue does this PR close?

Closes #18 .

## Rationale for this change

+ Calling `spark.catalog.clearCache()` clears the cached tables.
+ We can execute each query without side effect.

## What changes are included in this PR?

+ Call `spark.catalog.clearCache()` when executing each query beforehand.

## How are these changes tested?

+ By running `tpcbench.py`