### PR TITLE
Update tpcds tools to tpc-ds-tool 4.0.0

### DIFF
--- a/tpcds/Dockerfile
+++ b/tpcds/Dockerfile
@@ -5,7 +5,7 @@ RUN apt update && apt install -y zip gcc make flex bison byacc git
 # TPC-DS generator
 COPY tpc-ds-tool.zip .
 RUN unzip tpc-ds-tool.zip
-WORKDIR /DSGen-software-code-3.2.0rc1/tools
+WORKDIR /DSGen-software-code-4.0.0/tools
 
 # Fix bad UTF-8 char
 RUN iconv -f ISO-8859-14 -t UTF-8 tpcds.dst > tpcds.dst2


### PR DESCRIPTION
The link to download  the TPC-DS data generator (tpc-ds-tool.zip) https://www.tpc.org/tpc_documents_current_versions/current_specifications5.asp was updated with latest 4.0.0.

The current `tpcds/Dockerfile` doesn't work with it. This patch fixes it.